### PR TITLE
Bump rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 2.1.5
+  - 2.2.4

--- a/aroi.gemspec
+++ b/aroi.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", ">= 3.2", "< 5.0"
+  spec.add_dependency "rails", ">= 3.2", "< 5.1"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"

--- a/lib/aroi/version.rb
+++ b/lib/aroi/version.rb
@@ -1,3 +1,3 @@
 module Aroi
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
I don't see any relevant 5.0 api changes. Any reason to prevent the bump?
